### PR TITLE
Add one test case - create token cashbox twice

### DIFF
--- a/tests/kaching-cash-register/create-token-cashbox/create-cashbox-twice.spec.ts
+++ b/tests/kaching-cash-register/create-token-cashbox/create-cashbox-twice.spec.ts
@@ -1,0 +1,13 @@
+import { shouldFail } from "../../utils/testing";
+import { createTokenCashbox } from "../../utils/token-cashbox";
+import { registerCreateTokenCashboxTest } from "./runner";
+
+registerCreateTokenCashboxTest(
+  "should failed to create a token cashbox twice",
+  async (env) => {
+    const [cashBox1] = await createTokenCashbox(env);
+    return shouldFail(async () => {
+      await createTokenCashbox(env);
+    }, `Allocate: account Address { address: ${cashBox1.toBase58()}, base: None } already in use`);
+  }
+);


### PR DESCRIPTION
According to our dev team to broken-window, I add new test case to our Ka-Ching service.
Test case include: _A test for creating a token cashbox twice_